### PR TITLE
🐛 Fix : 부모 경로가 자식 경로에서 활성화되는 문제 해결

### DIFF
--- a/src/components/Tab/TabNavLinkItem.tsx
+++ b/src/components/Tab/TabNavLinkItem.tsx
@@ -6,7 +6,6 @@ interface TabNavLinkItemProps {
   as?: typeof Link | typeof NavLink;
   title: string;
   href: string;
-  className?: string;
   itemClass?: string;
   activeClass?: string;
 }
@@ -21,19 +20,21 @@ const TabNavLinkItem: React.FC<TabNavLinkItemProps> = (props) => {
     ...attributes
   } = props;
 
-  const classes =
-    Component === NavLink
-      ? ({ isActive }: { isActive: boolean }) =>
-        clsx(itemClass, isActive && activeClass)
-      : clsx(itemClass);
-
   return (
     <li {...attributes}>
-      <Component
-        to={href}
-        className={classes}>
-        {title}
-      </Component>
+      {Component === NavLink ? (
+        <NavLink
+          to={href}
+          className={({ isActive }) => clsx(itemClass, isActive && activeClass)}>
+          {title}
+        </NavLink>
+      ) : (
+        <Link
+          to={href}
+          className={clsx(itemClass)}>
+          {title}
+        </Link>
+      )}
     </li>
   );
 };

--- a/src/components/Tab/TabNavLinkItem.tsx
+++ b/src/components/Tab/TabNavLinkItem.tsx
@@ -25,7 +25,9 @@ const TabNavLinkItem: React.FC<TabNavLinkItemProps> = (props) => {
       {Component === NavLink ? (
         <NavLink
           to={href}
-          className={({ isActive }) => clsx(itemClass, isActive && activeClass)}>
+          end // 부모 경로와 자식 경로가 겹치는 문제 해결
+          className={({ isActive }) =>
+            clsx(itemClass, isActive && activeClass)}>
           {title}
         </NavLink>
       ) : (


### PR DESCRIPTION
> ## PR 타입
- [ ] 기능 추가
- [ ] 리팩토링
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

> ## 변경 사항
- `TabNavLinkItem` 컴포넌트에서 `NavLink`의 `end` 속성을 추가하여 부모 경로(`/company/profile`)가 자식 경로(`/company/profile/history`, `/company/profile/contact`)에서도 활성화되는 문제를 수정하였습니다.

<br/>

> ## 변경 전 문제
- 기존에는 `/company/profile`이 `/company/profile/history` 또는 `/company/profile/contact`의 부모 경로로 인식되어 "회사 소개" 탭이 계속 활성화되는 문제가 있었습니다.

<br/>

> ## 변경 후 기대 효과
- 현재 경로와 정확히 일치하는 탭만 활성화됨
- 사용자 경험(UX) 개선 및 올바른 내비게이션 동작 보장

<br/>

> ## 테스트 방법
1. `/company/profile` → "회사 소개" 탭 활성화 확인  
2. `/company/profile/history` → "회사 연혁" 탭 활성화 확인
3. `/company/profile/contact` → "오시는 길" 탭 활성화 확인