### PR TITLE
refactor: HISTORY에있는 중앙의 제목텍스트 왼쪽 정렬되게 수정

### DIFF
--- a/src/features/profile/pages/History.tsx
+++ b/src/features/profile/pages/History.tsx
@@ -34,7 +34,7 @@ const History = () => {
       ref={sectionRef}
       className="mx-auto min-h-screen w-full max-w-3xl py-16 md:py-32 px-4 overflow-x-hidden"
     >
-      <div className="mb-10 md:mb-20 font-bold text-center">
+      <div className="mb-10 md:mb-20 font-bold ">
         <h2 className="mb-4 md:mb-10 text-2xl md:text-4xl">
           <span className="text-primary">비젼라이프</span>가 걸어온 길
         </h2>


### PR DESCRIPTION
> ## PR 타입
- [ ] 기능 추가
- [X] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

> ## 변경 사항
중앙에 있던 제목을 왼쪽으로 정렬되게 하였습니다

<br/>

> ## 변경 전 문제
제목 텍스트가 중앙에 위치

<br/>

> ## 변경 후 기대 효과
제목 텍스트가 올바르게 왼쪽에 정렬

<br/>

![image](https://github.com/user-attachments/assets/03e7620e-6312-4a59-8054-8a6f6f3de174)
