### PR TITLE
feat: 모바일 메뉴 외부 클릭 감지 기능 추가 

### DIFF
--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+
+function useOnClickOutside(ref: React.RefObject<HTMLElement>, handler: (event: MouseEvent | TouchEvent) => void) {
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      // 클릭한 요소가 ref 내부에 있으면 아무 동작도 안함
+      if (!ref.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
+      handler(event);
+    };
+    //mousedown 마우스 버튼을 눌렀을 때 발생
+    //touchstart 모바일 화면에서 터치했을 때 발생
+    document.addEventListener("mousedown", listener);
+    document.addEventListener("touchstart", listener);
+
+    return () => {
+      document.removeEventListener("mousedown", listener);
+      document.removeEventListener("touchstart", listener);
+    };
+  }, [ref, handler]);
+}
+
+export default useOnClickOutside;

--- a/src/layout/Navigation.tsx
+++ b/src/layout/Navigation.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { NavLink, Link } from "react-router-dom";
 import Header from "./Header.tsx";
+import useOnClickOutside from "../hooks/useOnClickOutside.ts";
 
 const navigation = [
   {
@@ -36,10 +37,18 @@ const Navigation = () => {
   const [isDropdownVisible, setDropdownVisible] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [openSubmenus, setOpenSubmenus] = useState<{ [key: number]: boolean }>({});
+  const mobileMenuContainerRef = useRef<HTMLDivElement>(null);
+
 
   const toggleSubmenu = (index: number) => {
     setOpenSubmenus((prev) => ({ ...prev, [index]: !prev[index] }));
   };
+
+  useOnClickOutside(mobileMenuContainerRef, () => {
+    if (mobileMenuOpen) {
+      setMobileMenuOpen(false);
+    }
+  });
 
   return (
     <Header>
@@ -49,7 +58,6 @@ const Navigation = () => {
         onMouseEnter={() => setDropdownVisible(true)}
         onMouseLeave={() => setDropdownVisible(false)}
       >
-        {/* 헤더 영역 */}
         <div className="mx-auto max-w-6xl px-4">
           <div className="flex items-center justify-between py-4 h-18">
             {/* 로고 영역 */}
@@ -77,11 +85,10 @@ const Navigation = () => {
                 ))}
               </ul>
             </nav>
-            {/* 오른쪽 공백 */}
             <div className="w-32" />
           </div>
         </div>
-        {/* 하위 메뉴 백그라운드 영역 */}
+        {/* 하위 메뉴 영역 */}
         <div
           className={`absolute inset-x-0 top-full bg-white border-t border-gray-200 shadow-md transition-all duration-300 ease-in-out mt- ${
             isDropdownVisible ? "opacity-100 visible" : "opacity-0 invisible"
@@ -89,7 +96,6 @@ const Navigation = () => {
         >
           <div className="mx-auto max-w-6xl px-4">
             <div className="flex">
-              {/* 상위 메뉴와 동일한 좌우 여백 */}
               <div className="w-32" />
               <div className="flex-1">
                 <ul className="grid grid-cols-4 text-center">
@@ -118,8 +124,7 @@ const Navigation = () => {
       </div>
 
       {/* 모바일 내비게이션 */}
-      <div className="md:hidden">
-        {/* 로고와 햄버거 버튼 */}
+      <div className="md:hidden" ref={mobileMenuContainerRef}>
         <div className="flex justify-between items-center px-4 py-4 border-b border-gray-200">
           <h1 className="text-xl font-bold">
             <Link to="/">
@@ -167,8 +172,6 @@ const Navigation = () => {
             )}
           </button>
         </div>
-
-        {/* 모바일 메뉴 */}
         {mobileMenuOpen && (
           <nav className="px-4 py-2">
             <ul className="space-y-2">


### PR DESCRIPTION
> ## PR 타입
- [X] 기능 추가
- [ ] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

> ## 변경 사항
- 컴포넌트 외부 클릭시 특정 동작을 실행하는 훅을 생성하였습니다 35ff86520b6d9789e3ae1d6fd611c312cdeb1871
- useOnClickOutside 훅을 추가하여 외부 클릭 시 모바일 메뉴가 닫히도록 개선하였습니다.
8c4faae1b9538190d735a36d4c485bd587d8e4ab
<br/>

> ## 변경 전 문제
이전에는 반응형 네비게이션에서 외부 클릭시 네비게이션이 닫히지 않았습니다.
<br/>

> ## 변경 후 기대 효과
메뉴 외부를 클릭시 자동으로 메뉴가 닫히도록 개선됩니다.

<br/>

> ## 테스트 방법 (선택)
**테스트는 선택 사항이지만, 가능하면 작성해주세요!**
1. 개발자 도구를 들어가서 모바일 해상도로 변경합니다
2. 햄버거 메뉴를 클릭하고 네비게이션 외부를 클릭합니다.
3. 반응형 네비게이션이 닫히는지 확인합니다.