### PR TITLE
refactor: 제품 개요 섹션 리스트 정렬 방식 변경

### DIFF
--- a/src/features/business-overview/pages/Utex.tsx
+++ b/src/features/business-overview/pages/Utex.tsx
@@ -43,7 +43,7 @@ const Utex = () => {
               </div>
               <ul className="w-full max-w-2xl space-y-3">
                 {overview.items.map((item, idx) => (
-                  <li key={item.id} className="flex items-start gap-3">
+                  <li key={item.id} className="flex items-center gap-3">
                     <div className="shrink-0">
                       <BulletPoint bulletPoints={String(idx + 1)} />
                     </div>


### PR DESCRIPTION
- 리스트 항목의 items-start에서 items-center로 변경하여 정렬 방식 조정
- 스타일링 개선을 통한 불릿포인트와  텍스트 정렬

> ## PR 타입
- [ ] 기능 추가
- [X] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

> ## 변경 사항
- 리스트 항목의 items-start에서 items-center로 변경하여 정렬 방식 조정  
- 스타일링 개선을 통한 불릿 포인트와 텍스트  정렬  


<br/>

> ## 변경 전 문제
불릿포인트와 텍스트가 정렬되지 않았습니다.

<br/>

> ## 변경 후 기대 효과
불릿포인트와 텍스트가 정렬됩니다.

<br/>

![image](https://github.com/user-attachments/assets/5a2a4a9a-5fa8-47f8-91bd-dbfbce497fcd)


> ## 테스트 방법 (선택)
**테스트는 선택 사항이지만, 가능하면 작성해주세요!**
1. (테스트를 진행하는 방법을 설명하세요.)
2. (예: 특정 페이지에서 버튼 클릭 후 동작 확인 등)  