### PR TITLE
:recycle: Refactor - Footer 반응형 디자인 수정

### DIFF
--- a/src/layout/Footer/FooterColumn.tsx
+++ b/src/layout/Footer/FooterColumn.tsx
@@ -1,5 +1,7 @@
-import React, {memo, useMemo} from 'react';
+import React, {memo, useMemo, useState} from 'react';
 import {Link} from 'react-router-dom';
+import {FaChevronDown, FaChevronUp} from 'react-icons/fa';
+import clsx from 'clsx';
 
 interface FooterColumnProps {
   title: string;
@@ -13,21 +15,38 @@ interface SubLinks {
 
 const FooterColumn: React.FC<FooterColumnProps> = memo((props) => {
   const {title, subLinks} = props;
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleClick = () => setIsOpen(!isOpen);
+
   const sortedLinks = useMemo(() => {
     return [...subLinks].sort((a, b) => a.name.localeCompare(b.name));
   }, [subLinks]);
 
+  const titleClasses = clsx(`
+  w-full py-5 flex justify-between  items-center gap-2 text-lg font-semibold cursor-pointer 
+  md:mb-4 md:py-0 md:cursor-default md:justify-around`)
+
+  const listClasses = clsx(`
+   md:max-h-full md:opacity-100 md:text-center
+   text-left overflow-hidden transition-all duration-300 
+  ${isOpen 
+    ? "pb-6 max-h-40 opacity-100" 
+    : "pb-0 max-h-0 opacity-0"}`)
+
   return (
-    <div className="flex flex-col items-center">
-      <strong className="text-lg font-semibold mb-4">
+    <div className="w-full max-w-xs mx-auto flex flex-col md:items-center border-b border-b-gray-300 sm:border-b-0">
+      <strong className={titleClasses} onClick={handleClick}>
         {title}
+        <span className="text-gray-400 md:hidden">
+          {isOpen ? <FaChevronUp/> : <FaChevronDown/>}
+        </span>
       </strong>
-      <ul className="space-y-2 text-center">
+      {/*<ul className="space-y-2 text-center">*/}
+      <ul className={listClasses}>
         {sortedLinks.map((item, index) => (
-          <li key={index} className="hover:text-primary transition">
-            <Link to={item.path} className="hover:text-primary transition">
-              {item.name}
-            </Link>
+          <li key={index} className="pb-5 hover:text-primary transition md:pb-0">
+            <Link to={item.path}>{item.name}</Link>
           </li>
         ))}
       </ul>

--- a/src/layout/Footer/index.tsx
+++ b/src/layout/Footer/index.tsx
@@ -32,7 +32,6 @@ const Footer = memo(() => {
       ],
     },
   ],[]);
-
   const policy = useMemo(() => [
     { name: "개인정보 처리방침", path: "/policies/privacy" },
     { name: "이용약관", path: "/policies/terms" },
@@ -42,7 +41,7 @@ const Footer = memo(() => {
   return (
     <footer className="border-t border-t-gray-200 bg-[#f3f3f3] py-10">
       <div className="max-w-4xl mx-auto">
-        <div className="max-w-3xl mx-auto flex justify-around text-base">
+        <div className="max-w-3xl mx-auto flex flex-col gap-5 md:flex-row md:gap-0 justify-around text-base">
           {footer.map((item, index) => (
             <FooterColumn
               key={index}
@@ -55,7 +54,7 @@ const Footer = memo(() => {
         <div className="border-t border-t-gray-200 my-8"></div>
 
         {/*저작권*/}
-        <div className="px-4 flex justify-between items-center gap-4 text-base">
+        <div className="px-4 flex flex-col-reverse sm:flex-row justify-between items-center gap-4 text-base">
           <p className=" text-center">© 2025 VisionLife. All Rights Reserved.</p>
           <div className="text-sm flex flex-wrap justify-center gap-4">
             {policy.map((item, index) => (


### PR DESCRIPTION
> ## PR 타입
- [ ] 기능 추가
- [x] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

> ## 변경 사항
- 기존 리스트 형식에서 드롭다운 UI 형식으로 변경하여 가독성을 개선했습니다.
- 모바일 환경에서 strong 태그에 cursor-pointer를 적용하여 사용자가 클릭 가능하다는 점을 명확하게 전달했습니다.
- isOpen 상태를 활용하여 Footer 데이터의 가시성을 조정했습니다.
   - isOpen = false → 메뉴가 접힌 상태로 최소한의 공간만 차지합니다.
   - isOpen = true → 사용자가 클릭하면 메뉴가 펼쳐지면서 모든 데이터를 표시합니다.

### isOpen = false
![image](https://github.com/user-attachments/assets/0c7fd364-223f-4ef0-8956-fe64ebaea949)

### isOpen = true
![image](https://github.com/user-attachments/assets/c7c4215e-b8a8-47ef-962b-7c0b3da3d776)

<br/>

> ## 변경 전 문제
- 기존 리스트 형식이 길어져 스크롤이 증가하고, 가독성이 떨어지는 문제가 있었습니다.
- 모바일 환경에서 항목들이 한 번에 표시되어 UI가 복잡해지는 문제가 있었습니다.
- 클릭 가능한 요소인지 명확하지 않아 UX가 부족했습니다.