### PR TITLE
feat : 외부 클릭 시 모바일 메뉴 닫히는 훅 생성

### DIFF
--- a/src/hooks/useOnClickOutside.ts
+++ b/src/hooks/useOnClickOutside.ts
@@ -1,0 +1,43 @@
+import { useEffect, RefObject } from "react";
+
+/**
+ * 외부 클릭 시 실행할 핸들러 함수의 타입입니다.
+ * @param {Event} event - 발생한 이벤트 객체
+ */
+interface ClickOutsideHandler {
+  (event: Event): void;
+}
+
+/**
+ * 주어진 ref 요소 외부에서 발생하는 클릭 이벤트를 감지하여 handler 함수를 실행합니다.
+ *
+ * @param {RefObject<HTMLElement>} ref - 외부 클릭을 감지할 대상 요소의 ref 객체
+ * @param {ClickOutsideHandler} handler - 외부 클릭 시 실행할 콜백 함수
+ * @
+ * @remarks
+ * - ref는 객체이므로 의존성 배열에서 제외하여 불필요한 리렌더링을 방지합니다.
+ * - handler 함수는 매 렌더링마다 새로 생성될 가능성이 있으므로, 최적화를 위해 useCallback을 사용하세요.
+ */
+function useOnClickOutside(
+  ref: RefObject<HTMLElement>,
+  handler: ClickOutsideHandler
+) {
+  useEffect(() => {
+    const listener = (event: Event) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
+      handler(event);
+    };
+
+    document.addEventListener("mousedown", listener);
+    document.addEventListener("touchstart", listener);
+
+    return () => {
+      document.removeEventListener("mousedown", listener);
+      document.removeEventListener("touchstart", listener);
+    };
+  }, [handler]); // ref는 객체이므로 의존성 배열에서 제거
+}
+
+export default useOnClickOutside;


### PR DESCRIPTION
> ## PR 타입
- [X] 기능 추가
- [ ] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

> ## 변경 사항
useOnClickOutside 훅을 추가하여 외부 클릭 시 모바일 메뉴가 닫히도록 개선하였습니다.
useOnClickOutside 훅 최적화 및 타입 개선을 하였습니다 

<br/>

> ## 변경 전 문제
이전에는 반응형 네비게이션에서 외부 클릭시 네비게이션이 닫히지 않았습니다.

<br/>

> ## 변경 후 기대 효과
메뉴 외부를 클릭시 자동으로 메뉴가 닫히도록 개선됩니다.

<br/>

> ## 테스트 방법 (선택)
**테스트는 선택 사항이지만, 가능하면 작성해주세요!**
1. (테스트를 진행하는 방법을 설명하세요.)
2. (예: 특정 페이지에서 버튼 클릭 후 동작 확인 등)  