### PR TITLE
refactor: 뉴스 페이지 레이아웃 및 스타일 개선

### DIFF
--- a/src/features/news/components/FeaturedNews.tsx
+++ b/src/features/news/components/FeaturedNews.tsx
@@ -20,7 +20,6 @@ const FeaturedNews: React.FC = () => {
 
   return (
     <section className="mx-auto max-w-screen-xl px-4 sm:px-6 md:px-8 py-6">
-      <hr className="border-primary mb-6" />
       <div className="grid grid-cols-1 gap-4 sm:gap-6 md:grid-cols-2 lg:grid-cols-3 xl:gap-8">
         {featuredNews.map((news) => (
           <div
@@ -44,7 +43,6 @@ const FeaturedNews: React.FC = () => {
           </div>
         ))}
       </div>
-      <hr className="border-primary mt-6" />
     </section>
   );
 };

--- a/src/features/news/index.tsx
+++ b/src/features/news/index.tsx
@@ -9,18 +9,16 @@ const News: React.FC = () => {
 
   return (
     <PageLayout title="뉴스 페이지 본문">
-      <div className="mx-4 sm:mx-20">
-        <h1 className="mt-20 mb-20 w-full text-center text-4xl font-bold text-gray-900">
+      <div className="mx-auto max-w-screen-xl px-4 sm:px-6 md:px-8">
+        <h1 className="mt-12 sm:mt-16 lg:mt-20 mb-8 w-full text-center text-4xl font-bold text-gray-900">
           언론 보도
         </h1>
-
+        <hr className="border-primary mb-6 py-1" />
         {/* 상세 페이지인 경우 뉴스 목록 숨기고 DetailNews만 표시 */}
         {id && <Outlet />}
         {!id && (
           <>
-            <hr className="border-primary mt-1" />
             <FeaturedNews />
-            <hr className="border-primary mt-1" />
             <NewsList />
           </>
         )}


### PR DESCRIPTION
- 컨테이너 크기 조정 max-w-screen-xl
- 제목  마진 조정
- 불필요한 hr 제거

> ## PR 타입
- [ ] 기능 추가
- [X] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

> ## 변경 사항
- 컨테이너 크기 조정 max-w-screen-xl
- 제목  마진 조정
- 불필요한 hr 제거
<br/>

> ## 변경 전 문제
언론 보도 페이지의 border가 예상치 못하게 추가 되었습니다.
<br/>

> ## 변경 후 기대 효과
언론 보도 페이지의 border가 정상적으로 출력됩니다
![image](https://github.com/user-attachments/assets/9acfc1cc-fdba-41cb-a52c-8820c23e8394)

<br/>

> ## 테스트 방법 (선택)
**테스트는 선택 사항이지만, 가능하면 작성해주세요!**
1. (테스트를 진행하는 방법을 설명하세요.)
2. (예: 특정 페이지에서 버튼 클릭 후 동작 확인 등)  