### PR TITLE
refactor: 기업 연혁 반응형 페이지 제목,텍스트 왼쪽부터 출력되게 변경

### DIFF
--- a/src/features/profile/pages/History.tsx
+++ b/src/features/profile/pages/History.tsx
@@ -50,12 +50,12 @@ const History = () => {
             key={item.id}
             className="history_item flex flex-col md:flex-row items-center md:items-start justify-start gap-2 md:gap-10"
           >
-            <h4 className="w-full md:w-1/6 text-center md:text-right text-xl md:text-2xl font-semibold">
+            <h4 className="w-full md:w-1/6 text-left md:text-right text-xl md:text-2xl font-semibold">
               {item.year.includes('~')
                 ? `${item.year.split('~')[0]}년 ~ ${item.year.split('~')[1]}년`
                 : `${item.year}년`}
             </h4>
-            <div className="w-full md:w-5/6 text-center md:text-left text-base md:text-xl">
+            <div className="w-full md:w-5/6 text-left md:text-left text-base md:text-xl">
               {Array.isArray(item.event) ? (
                 <>
                   {item.event.map((subEvent, index) => (


### PR DESCRIPTION
> ## PR 타입
- [ ] 기능 추가
- [X] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

> ## 변경 사항
기업 연혁 페이지의 반응형 페이지에서 제목과 텍스트가 왼쪽에 위치하게 변경하였습니다

<br/>

> ## 변경 전 문제
이전에는 의도와 다르게 제목과 텍스트가 중앙 위치하였습니다

<br/>

> ## 변경 후 기대 효과
기업 연혁 페이지의 제목과 텍스트가 올바른 위치에 위치합니다
![image](https://github.com/user-attachments/assets/c335e4ab-a7bf-4524-b30a-8a453ed1bcab)

<br/>

> ## 테스트 방법 (선택)
**테스트는 선택 사항이지만, 가능하면 작성해주세요!**
1. (테스트를 진행하는 방법을 설명하세요.)
2. (예: 특정 페이지에서 버튼 클릭 후 동작 확인 등)  