### PR TITLE
refactor: 모든 소식 보기 클릭시 언론 보도 페이지로 이동하도록 변경

### DIFF
--- a/src/features/home/components/MoreNewsSection.tsx
+++ b/src/features/home/components/MoreNewsSection.tsx
@@ -9,7 +9,7 @@ const MoreNewsSection = () => {
           더 많은 소식 확인하기
         </h3>
         <TextLink
-          href="/"
+          href="/company/news"
           size="lg"
           className="flex items-center gap-3 font-extrabold">
           <LuCircleArrowRight className="text-primary font-extrabold" />


### PR DESCRIPTION
> ## PR 타입
- [ ] 기능 추가
- [X] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

> ## 변경 사항
- 메인페이지의 모든 소식 보기를 클릭하면 언론보도 페이지로 이동하도록 변경하였습니다.

<br/>

> ## 변경 전 문제
- 이전에는 모든 소식 보기를 클릭하면 언론보도 페이지가 아닌 메인페이지로 다시 이동하였습니다

<br/>

> ## 변경 후 기대 효과
- 모든 소식 보기를 클릭하면 올바른 언론보도 페이지로 이동합니다.
<br/>

> ## 테스트 방법 (선택)
**테스트는 선택 사항이지만, 가능하면 작성해주세요!**
1. (테스트를 진행하는 방법을 설명하세요.)
2. (예: 특정 페이지에서 버튼 클릭 후 동작 확인 등)  