### PR TITLE
refactor: 주소 아이콘 백그라운드 크기 다른 아이콘들과 동일하게 변경

### DIFF
--- a/src/features/profile/pages/ContactUs.tsx
+++ b/src/features/profile/pages/ContactUs.tsx
@@ -3,6 +3,7 @@ import { FaPhoneAlt } from 'react-icons/fa';
 import { LiaFaxSolid } from 'react-icons/lia';
 import { MdOutlineMail } from 'react-icons/md';
 import { HiOutlineLocationMarker } from 'react-icons/hi';
+import DummyImgBox from '../../../components/DummyImgBox.tsx';
 import SectionLayout from '../../../layout/SectionLayout.tsx';
 
 const ContactUs = () => {
@@ -47,7 +48,7 @@ const ContactUs = () => {
             title="주소"
             type="_base"
             icon={
-              <HiOutlineLocationMarker className="bg-primary h-12 w-12 sm:h-14 sm:w-16 rounded-full p-2 sm:p-3 text-white" />
+              <HiOutlineLocationMarker className="bg-primary h-12 w-12 sm:h-14 sm:w-14 rounded-full p-2 sm:p-3 text-white" />
             }
             description="서울 서초구 반포대로 21길 23 세진빌딩 3층"
             size="w-full h-full"
@@ -55,12 +56,7 @@ const ContactUs = () => {
         </ul>
         {/* 이미지 영역 */}
         <div className="lg:col-span-3">
-          <img
-            src="/img/contactus/map.png"
-            alt="Contact Us Map"
-            className="w-full h-full object-cover object-center transform scale-110 md:scale-100"
-          />
-
+          <DummyImgBox width="w-full" height="h-full" isCircle={false} />
         </div>
       </div>
     </SectionLayout>


### PR DESCRIPTION
> ## PR 타입
- [ ] 기능 추가
- [X] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

> ## 변경 사항
주소 아이콘의 백그라운드의 크기를 다른 아이콘들과 동일하게 변경하였습니다.

<br/>

> ## 변경 전 문제
이전의 주소 아이콘 백그라운드는 다른 아이콘의 백그라운드와 다르게 가로 길이가 좀 길었습니다

<br/>

> ## 변경 후 기대 효과
다른 아이콘의 백그라운드 크기와 같게 표시됩니다.
![image](https://github.com/user-attachments/assets/8519e6b0-87e0-4eea-91c0-3b337bedcf12)

<br/>

> ## 테스트 방법 (선택)
**테스트는 선택 사항이지만, 가능하면 작성해주세요!**
1. (테스트를 진행하는 방법을 설명하세요.)
2. (예: 특정 페이지에서 버튼 클릭 후 동작 확인 등)  