### PR TITLE
refactor: 사업 소개 페이지 모바일 좌우 여백 추가 및 레이아웃 정리

### DIFF
--- a/src/features/business-overview/pages/Overview.tsx
+++ b/src/features/business-overview/pages/Overview.tsx
@@ -25,19 +25,20 @@ const Overview = () => {
             무폐수 디지털 나염 시스템
           </h3>
         </div>
+        <div className="px-4 md:px-8">
+          <article className="mx-auto w-full max-w-lg md:max-w-2xl lg:max-w-4xl md:text-xl leading-relaxed">
+            <div className="border-l-4 border-primary pl-4 md:pl-6">
+              {overview.description.map((line: string, index: number) => (
+                <p key={index} className="mt-3 md:mt-4">{line}</p>
+              ))}
+            </div>
+          </article>
 
-        <article className="mx-auto w-full max-w-lg md:max-w-2xl lg:max-w-4xl md:text-xl leading-relaxed">
-          <div className="border-l-4 border-primary pl-4 md:pl-6">
-            {overview.description.map((line: string, index: number) => (
-              <p key={index} className="mt-3 md:mt-4">{line}</p>
-            ))}
-          </div>
-        </article>
-
-        <div className="w-full pt-32 space-y-12 md:space-y-10 lg:space-y-12">
-          <OverviewList data={overview.features} />
-          <div className="pt-20">
-            <BenefitList data={overview.benefits} />
+          <div className="w-full pt-32 space-y-12 md:space-y-10 lg:space-y-12">
+            <OverviewList data={overview.features} />
+            <div className="pt-20">
+              <BenefitList data={overview.benefits} />
+            </div>
           </div>
         </div>
       </SectionLayout>


### PR DESCRIPTION
> ## PR 타입
- [X] 기능 추가
- [X] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

> ## 변경 사항
- px-4 md:px-8 추가하여 반응형에서 좌우 여백 확보
- div추가하여 article 및 리스트 레이아웃 정리

<br/>

> ## 변경 전 문제
이전 사업 소개 모바일 페이지는 섹션의 좌우에 여백이없어 텍스트가 창 끝에 붙어보여서 가시성이 떨어졌습니다.
<br/>

> ## 변경 후 기대 효과
사업 소개 페이지 모바일 화면일때 좌우 여백 추가되어 보기가 편해졌습니다.
![image](https://github.com/user-attachments/assets/72fdd9d3-e59c-4232-8d0f-e8aa1016725b)

![image](https://github.com/user-attachments/assets/6830aad3-af45-4b0c-a790-b9c6028f8f4e)

<br/>


> ## 테스트 방법 (선택)
**테스트는 선택 사항이지만, 가능하면 작성해주세요!**
1. (테스트를 진행하는 방법을 설명하세요.)
2. (예: 특정 페이지에서 버튼 클릭 후 동작 확인 등)  