### PR TITLE
refactor: footer 레이아웃 수정 및 페이지네이션 cursor-pointer 추가

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -17,7 +17,9 @@ const Pagination: React.FC<PaginationProps> = ({
     <div className="mt-16 flex flex-wrap justify-center items-center gap-2 sm:gap-4">
       <button
         className={`px-4 sm:px-8 py-1 text-base sm:text-lg ${
-          currentPage === 1 ? 'cursor-not-allowed opacity-50' : 'hover:underline'
+          currentPage === 1 
+            ? 'cursor-not-allowed opacity-50' 
+            : 'cursor-pointer hover:underline'
         }`}
         onClick={() => currentPage > 1 && onPageChange(currentPage - 1)}
         disabled={currentPage === 1}
@@ -31,7 +33,7 @@ const Pagination: React.FC<PaginationProps> = ({
         return (
           <button
             key={pageNumber}
-            className={`px-3 sm:px-6 py-1 text-base sm:text-lg transition-colors rounded ${
+            className={`px-3 sm:px-6 py-1 text-base sm:text-lg cursor-pointer ${
               currentPage === pageNumber
                 ? 'font-bold !text-primary'
                 : 'text-gray-700 hover:text-primary'
@@ -45,7 +47,9 @@ const Pagination: React.FC<PaginationProps> = ({
 
       <button
         className={`px-4 sm:px-8 py-1 text-base sm:text-lg ${
-          currentPage === totalPages ? 'cursor-not-allowed opacity-50' : 'hover:underline'
+          currentPage === totalPages 
+            ? 'cursor-not-allowed opacity-50'
+            : 'cursor-pointer hover:underline'
         }`}
         onClick={() =>
           currentPage < totalPages && onPageChange(currentPage + 1)

--- a/src/layout/Footer/index.tsx
+++ b/src/layout/Footer/index.tsx
@@ -41,7 +41,7 @@ const Footer = memo(() => {
   return (
     <footer className="border-t border-t-gray-200 bg-[#f3f3f3] py-10">
       <div className="max-w-4xl mx-auto">
-        <div className="max-w-3xl mx-auto flex flex-col gap-5 md:flex-row md:gap-0 justify-around text-base">
+        <div className="max-w-4xl mx-auto flex flex-col gap-5 md:flex-row md:gap-20 justify-between text-base">
           {footer.map((item, index) => (
             <FooterColumn
               key={index}


### PR DESCRIPTION
> ## PR 타입
- [ ] 기능 추가
- [X] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

> ## 변경 사항
footer 컬럼에 더 넓은 간격 적용 , 페이지네이션 cursor-pointer추가
<br/>

> ## 변경 전 문제
footer 컬럼이 좁았었습니다
페이지네이션에 마우스 오버시 기본값으로 나왔습니다
<br/>

> ## 변경 후 기대 효과
푸터 컬럼 간격이 넓어져 전체 레이아웃의 균형과 가독성이 향상됩니다.
페이지네이션 버튼에 cursor-pointer 효과가 적용되어 마우스 오버 시 사용자에게 인터랙션 가능하다는 시각적 피드백을 제공합니다.

![image](https://github.com/user-attachments/assets/35d957d2-a1ab-4e75-91bb-6e06a45220a1)

<br/>

> ## 테스트 방법 (선택)
**테스트는 선택 사항이지만, 가능하면 작성해주세요!**
1. (테스트를 진행하는 방법을 설명하세요.)
2. (예: 특정 페이지에서 버튼 클릭 후 동작 확인 등)  