### PR TITLE
refactor 메인페이지 반응형웹 테블릿 크기일시 모바일처럼 햄버거 메뉴 나오게 수정 및 로고 위치 조정

### DIFF
--- a/src/layout/Navbar/NavbarDesktop.tsx
+++ b/src/layout/Navbar/NavbarDesktop.tsx
@@ -22,11 +22,11 @@ const NavbarDesktop: React.FC<DesktopNavbarProps> = (props) => {
     isDropdownVisible ? 'opacity-100 visible' : 'opacity-0 invisible');
 
   return (
-    <div
-      className="hidden md:block relative"
-      >
-      <div className="mx-auto max-w-7xl flex items-center justify-between py-4 h-18">
+    <div className="hidden lg:block relative">
+    <div className="mx-auto max-w-7xl flex items-center justify-between py-4 h-18">
+      <div className="ml-3">
         <Logo type="_desktop" />
+      </div>
         <NavbarMenu
           type="_nav"
           items={navigation}

--- a/src/layout/Navbar/NavbarMobile.tsx
+++ b/src/layout/Navbar/NavbarMobile.tsx
@@ -26,7 +26,7 @@ const NavbarMobile: React.FC<MobileNavbarProps> = (props) => {
   } = props;
 
   return (
-    <div className="md:hidden">
+    <div className="lg:hidden">
       {/* 로고와 햄버거 버튼 */}
       <div className="flex justify-between items-center px-4 py-4 border-b border-gray-200">
         <Logo type="_mobile"/>


### PR DESCRIPTION
> ## PR 타입
- [ ] 기능 추가
- [X] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
> ### 변경 내용1
Navbar 데스크탑 브레이크포인트 변경 md 에서 lg로 변경 및 로고 위치 조정하였습니다
<br/>

> ### 변경 내용2
refactor: 모바일 메뉴 브레이크포인트 변경 md에서lg 변경하였습니다

<br/>

## 변경 전 문제 (선택)
> ### 변경 전 문제
아이패드 미니,에어 해상도에서 네비게이션의 메인메뉴,서브메뉴가 수직정렬이 되어 있지 않았습니다
<br/>

## 변경 후 기대 효과 (선택)
> ### 변경 후 기대 효과
아이패드 미니,에어 등 특정 해상도에서도 모바일처럼 햄버거 메뉴가 표시됩니다.
이제 로고가 왼쪽 창에 붙지 않습니다
![image](https://github.com/user-attachments/assets/9d3bfdaa-846c-4031-998e-a2cb9a65f1ad)
![image](https://github.com/user-attachments/assets/2f5ccbc5-7194-460e-91e8-38d2d1a01180)

