### PR TITLE
refactor: 뉴스페이지 모바일 화면의 좌우 여백 수정

### DIFF
--- a/src/features/news/components/NewsCardList.tsx
+++ b/src/features/news/components/NewsCardList.tsx
@@ -57,16 +57,18 @@ const NewsCardList: React.FC<NewsCardListProps> = (props) => {
           <Link
             to={`/company/news/${item.id}`}
             className={linkClasses}>
-            <div className={imgWrapClasses}>
+            <div className={clsx(imgWrapClasses, 'p-2' , 'mt-4')}>
               <img
                 src={item.imageUrl || `/img/news/default-image-${item.id}.jpg`}
                 alt={item.title}
                 className={imgClasses}
               />
+
             </div>
 
+
             {layout === "horizontal" && (
-              <div className="flex flex-col flex-grow">
+              <div className="flex flex-col flex-grow p-4">
                 <h3 className="mb-2 text-lg font-semibold text-gray-800">
                   {item.title}
                 </h3>
@@ -74,7 +76,7 @@ const NewsCardList: React.FC<NewsCardListProps> = (props) => {
             )}
 
             {layout === "vertical" && (
-              <div className="flex flex-col space-y-2">
+              <div className="flex flex-col space-y-2 p-4">
                 <div className="flex items-center space-x-2">
                   <h3 className="text-base sm:text-lg font-bold text-gray-800">
                     {truncateText(item.title, 50)}


### PR DESCRIPTION
> ## PR 타입
- [ ] 기능 추가
- [ ] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
> ### 변경 내용1
이미지 랩 요소에 p-2와 mt-4 클래스를 추가하여 이미지와 주변 요소 간의 적절한 간격을 확보하였습니다

<br/>

> ### 변경 내용2
horizontal및 vertical  레이아웃 컴포넌트에 p-4 클래스를 적용하여 내부 여백을 추가하였습니다


<br/>

## 변경 전 문제 (선택)
레이아웃 컴포넌트들의 여백이 부족해 콘텐츠가 화면에 너무 붙어 표시되어 가독성과 시각적 구분 좋지 않았습니다
<br/>

## 변경 후 기대 효과 (선택)
각 요소에 적절한 여백을 추가함으로써 가독성이 상승됩니다

![image](https://github.com/user-attachments/assets/ccfd15b2-a012-4aaa-8eb9-93020ac911c2)
모바일
![image](https://github.com/user-attachments/assets/dd31ed28-56f5-468a-a62b-773d1f4bcb0d)
아이패드 프로
![image](https://github.com/user-attachments/assets/2529fba8-7cea-4acf-8193-a5dcf5743345)
아이패드 에어