### PR TITLE
:sparkle: feat - 캐러셀 슬라이드 생성 및 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.4.0",
-        "react-router-dom": "^7.1.3"
+        "react-router-dom": "^7.1.3",
+        "swiper": "^11.2.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -25,6 +26,7 @@
         "@types/navermaps": "^3.7.9",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
+        "@types/swiper": "^5.4.3",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.17.0",
@@ -2909,6 +2911,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/swiper": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@types/swiper/-/swiper-5.4.3.tgz",
+      "integrity": "sha512-hJXpVeANf+XQXgbvmuFZdsnaSOKqOEZcaLDnHhZOJDRow+lfboatwubW+Ay9XiHobMGyEomkgpXSYRlDVn4gMQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7899,6 +7908,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.4.tgz",
+      "integrity": "sha512-DTtglrsFfMYytid+oNy4QI3t2N2+XhhwSYbnyOhlwBmvY8Bkoj3ombK1/b80w8vDpQ+Lqlnbm+0737+i32MrcA==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.4.0",
-    "react-router-dom": "^7.1.3"
+    "react-router-dom": "^7.1.3",
+    "swiper": "^11.2.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
@@ -32,6 +33,7 @@
     "@types/navermaps": "^3.7.9",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
+    "@types/swiper": "^5.4.3",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.17.0",

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Navigation, Pagination, Autoplay } from "swiper/modules";
+import "swiper/swiper-bundle.css";
+import news from "../data/news.json";
+import { Link } from "react-router-dom";
+
+const NewsCarousel: React.FC = () => {
+  return (
+    <div className="relative w-full h-full max-w-xs md:max-w-6xl mx-auto py-10 overflow-hidden">
+      <Swiper
+        modules={[Navigation, Pagination, Autoplay]}
+        spaceBetween={20}
+        navigation
+        pagination={{ clickable: true }}
+        autoplay={{ delay: 117000 }}
+        loop={true} // 무한 루프 활성화
+        breakpoints={{
+          320: { slidesPerView: 1, spaceBetween: 10 }, // 초소형 모바일
+          640: { slidesPerView: 1, spaceBetween: 15 }, // 모바일
+          768: { slidesPerView: 2, spaceBetween: 20 }, // 태블릿
+          1024: { slidesPerView: 3, spaceBetween: 30 }, // 데스크탑
+          1280: { slidesPerView: 3, spaceBetween: 40 }, // 대형 화면
+        }}>
+        {news.items.map((item) => (
+          <SwiperSlide key={item.id} className="mb-10">
+            <Link to={`/company/news/${item.id}`} className="mb-5 max-w-sm mx-auto block bg-gray-100 rounded-lg overflow-hidden transition-transform transform hover:scale-105">
+              <div className="relative md:w-full h-48 sm:h-56 md:h-64 lg:h-72 xl:h-80">
+                <img
+                  src={item.imageUrl || `/img/news/default-image.jpg`}
+                  alt={item.title}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+              <div className="h-32 p-4 text-center">
+                <h3 className="text-lg font-bold text-gray-900 line-clamp-2">{item.title}</h3>
+                <p className="pt-3 text-sm text-gray-500">
+                  {new Date(item.publishedDate).toLocaleDateString()}
+                </p>
+              </div>
+            </Link>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </div>
+  );
+};
+
+export default NewsCarousel;

--- a/src/components/SectionTitle.tsx
+++ b/src/components/SectionTitle.tsx
@@ -1,0 +1,16 @@
+const SectionTitle = ({
+  title,
+  preHeading
+}: {
+  title: string;
+  preHeading: string;
+}) => {
+  return (
+    <div className="mx-auto w-full max-w-4xl pt-32 pb-20 font-bold">
+      <p className="mb-8 text-5xl">{preHeading}</p>
+      <h2 className="text-4xl">{title}</h2>
+    </div>
+  );
+};
+
+export default SectionTitle;

--- a/src/features/news/components/NewsCardList.tsx
+++ b/src/features/news/components/NewsCardList.tsx
@@ -26,10 +26,10 @@ const NewsCardList: React.FC<NewsCardListProps> = (props) => {
   const listClasses = clsx(
     layout === 'horizontal' &&
       'grid grid-cols-1 gap-4 sm:gap-6 md:grid-cols-2 lg:grid-cols-3 xl:gap-8',
-    layout === 'vertical' && 'py-14 max-w-4xl mx-auto space-y-6'
+    layout === 'vertical' && 'pb-14 max-w-4xl mx-auto space-y-6'
   );
 
-  const itemClasses = clsx(layout === 'vertical' && 'my-14');
+  const itemClasses = clsx(layout === 'vertical' && 'my-5 md:my-14');
 
   const linkClasses = clsx(
     'flex flex-col transition duration-300 hover:opacity-80 overflow-hidden gap-4',
@@ -77,7 +77,7 @@ const NewsCardList: React.FC<NewsCardListProps> = (props) => {
                     {truncateText(item.title, 50)}
                   </h3>
                 </div>
-                <p className="text-sm leading-relaxed text-gray-600">
+                <p className="hidden md:block text-sm leading-relaxed text-gray-600">
                   {truncateText(item.content, 150)}
                 </p>
                 <p className="text-xs text-gray-500">

--- a/src/features/news/pages/News.tsx
+++ b/src/features/news/pages/News.tsx
@@ -1,14 +1,18 @@
 import NewsCardList from '../components/NewsCardList.tsx';
+import Carousel from '../../../components/Carousel.tsx';
 
 const News = () => {
   return (
-    <section className="mx-auto max-w-7xl">
-      <div className="mx-auto w-full max-w-4xl pt-32 pb-20 font-bold">
-        <h2 className="mb-8 text-5xl text-gray-900">언론 보도</h2>
-        <h3 className="text-2xl">비전라이프 최신 뉴스</h3>
+    <section className="mx-auto md:max-w-7xl">
+      <div className="mx-auto w-full max-w-xs md:max-w-full pt-20 md:pt-32 font-bold">
+        <p className="w-fit mb-4 px-1 text-sm md:text-base text-primary border-b border-b-primary font-semibold">언론 보도</p>
+        <h3 className="text-2xl md:text-4xl">비전라이프 최신 뉴스</h3>
       </div>
-      <NewsCardList layout="horizontal" />
-      <NewsCardList layout="vertical" />
+      <Carousel/>
+      <div className="w-full max-w-xs lg:max-w-4xl mx-auto pt-14">
+        <h3 className="text-2xl md:text-4xl font-bold">전체 뉴스</h3>
+        <NewsCardList layout="vertical" />
+      </div>
     </section>
   );
 };


### PR DESCRIPTION
- swiper 설치
- PC, 모바일 (z 플립5) 반응형 및 컴포넌트 작업 (CL: 453)

> ## PR 타입

- [x] 기능 추가
- [ ] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
> ### 의존성 설치
> swiper , @types/swiper 의존성이 추가되었습니다.

<br/>

> ### 캐러셀 슬라이드 컴포넌트 생성
- 캐러셀 슬라이드 컴포넌트(Carousel.tsx)가 추가되었습니다.
- 캐러셀 슬라이드는 현재 뉴스 페이지에 적용되어있으며 유틸리티하게 리팩토링 작업이 필요합니다.
- 현재 PC, Mobile 일부 기기 (Z fold5)에 최적화 되어있습니다.