### PR TITLE
refactor: ContactUs 컴포넌트 레이아웃 및 반응형 스타일링 개선

### DIFF
--- a/src/features/profile/pages/ContactUs.tsx
+++ b/src/features/profile/pages/ContactUs.tsx
@@ -1,76 +1,78 @@
-import ListCard from '../../../components/ListCard.tsx';
-import {FaPhoneAlt} from 'react-icons/fa';
-import {LiaFaxSolid} from 'react-icons/lia';
-import {MdOutlineMail} from 'react-icons/md';
-import {HiOutlineLocationMarker} from 'react-icons/hi';
-import SectionLayout from '../../../layout/SectionLayout.tsx';
-import NaverMap from '../../../components/Map/NaverMap.tsx';
+  import ListCard from '../../../components/ListCard.tsx';
+  import { FaPhoneAlt } from 'react-icons/fa';
+  import { LiaFaxSolid } from 'react-icons/lia';
+  import { MdOutlineMail } from 'react-icons/md';
+  import { HiOutlineLocationMarker } from 'react-icons/hi';
+  import SectionLayout from '../../../layout/SectionLayout.tsx';
+  import NaverMap from '../../../components/Map/NaverMap.tsx';
 
-const contactInfo = [
-  {
-    title: '대표번호',
-    icon: (
-      <FaPhoneAlt className="bg-primary h-12 w-12 rounded-full p-2 text-white sm:h-14 sm:w-14 sm:p-3" />
-    ),
-    description: '010-7563-1272',
-  },
-  {
-    title: '팩스 (FAX)',
-    icon: (
-      <LiaFaxSolid className="bg-primary h-12 w-12 rounded-full p-2 text-white sm:h-14 sm:w-14 sm:p-3" />
-    ),
-    description: '02-555-580',
-  },
-  {
-    title: '이메일',
-    icon: (
-      <MdOutlineMail className="bg-primary h-12 w-12 rounded-full p-2 text-white sm:h-14 sm:w-14 sm:p-3" />
-    ),
-    description: 'visionlife2018@naver.com',
-  },
-  {
-    title: '주소',
-    icon: (
-      <HiOutlineLocationMarker className="bg-primary h-12 w-12 rounded-full p-2 text-white sm:h-14 sm:w-16 sm:p-3" />
-    ),
-    description: '서울 서초구 반포대로 21길 23 세진빌딩 3층',
-  },
-];
+  const contactInfo = [
+    {
+      title: '대표번호',
+      icon: (
+        <FaPhoneAlt className="bg-primary h-12 w-12 flex-none rounded-full p-2 text-white sm:h-14 sm:w-14 sm:p-3" />
+      ),
+      description: '010-7563-1272',
+    },
+    {
+      title: '팩스 (FAX)',
+      icon: (
+        <LiaFaxSolid className="bg-primary h-12 w-12 flex-none rounded-full p-2 text-white sm:h-14 sm:w-14 sm:p-3" />
+      ),
+      description: '02-555-580',
+    },
+    {
+      title: '이메일',
+      icon: (
+        <MdOutlineMail className="bg-primary h-12 w-12 flex-none rounded-full p-2 text-white sm:h-14 sm:w-14 sm:p-3" />
+      ),
+      description: 'visionlife2018@naver.com',
+    },
+    {
+      title: '주소',
+      icon: (
+        <HiOutlineLocationMarker className="bg-primary h-12 w-12 flex-none rounded-full p-2 text-white sm:h-14 sm:w-14 sm:p-3" />
+      ),
+      description: '서울 서초구 반포대로 21길 23 세진빌딩 3층',
+    },
+  ];
 
-const ContactUs = () => {
-  return (
-    <SectionLayout
-      title="CONTACT US"
-      className="mx-auto flex max-w-6xl flex-col items-center justify-center py-12 sm:py-16 lg:py-20"
-      titleClassName="py-6 text-3xl lg:text-4xl font-semibold text-center"
-      fullHeight={false}>
-      <div className="grid w-full grid-rows-1 md:mt-10 md:grid-cols-2 lg:grid-cols-5">
+  const ContactUs = () => {
+    return (
+      <SectionLayout
+        title="CONTACT US"
+        className="mx-auto px-4 sm:px-6 md:px-8 lg:px-10 xl:px-12 flex max-w-6xl flex-col items-center justify-center py-12 sm:py-16 lg:py-20"
+        titleClassName="py-6 text-3xl lg:text-4xl font-semibold text-center"
+        fullHeight={false}
+      >
         {/* 연락처 정보 */}
-        <ul className="mx-auto flex max-w-sm flex-col gap-6 lg:col-span-2">
-          {contactInfo.map((item, index) => (
-            <ListCard
-              key={index}
-              title={item.title}
-              type="_base"
-              icon={item.icon}
-              description={item.description}
-              size="w-full h-full"
+        <div className="grid w-full grid-cols-1 md:mt-10 md:grid-cols-2 lg:grid-cols-5 gap-8 md:gap-12">
+          <ul className="mx-auto flex max-w-sm flex-col gap-6 lg:col-span-2">
+            {contactInfo.map((item, index) => (
+              <ListCard
+                key={index}
+                title={item.title}
+                type="_base"
+                icon={item.icon}
+                description={item.description}
+                size="w-full h-full"
+              />
+            ))}
+          </ul>
+
+          {/* 이미지 영역 */}
+          <div
+            id="map"
+            className="mx-auto max-w-sm w-full h-64 md:h-full lg:col-span-3 lg:mx-0 lg:max-w-full lg:h-full  rounded-2xl pt-10"
+          >
+            <NaverMap
+              latitude={37.48771788371748}
+              longitude={127.00855064427329}
             />
-          ))}
-        </ul>
-
-        {/* 이미지 영역 */}
-        <div
-          id="map"
-          className="h-96 w-full rounded-2xl pt-10 lg:col-span-3 lg:h-full lg:pt-0">
-          <NaverMap
-            latitude={37.48771788371748}
-            longitude={127.00855064427329}
-          />
+          </div>
         </div>
-      </div>
-    </SectionLayout>
-  );
-};
+      </SectionLayout>
+    );
+  };
 
-export default ContactUs;
+  export default ContactUs;


### PR DESCRIPTION
> ## PR 타입

- [X] 기능 추가
- [X] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항

> ### 반응형 적용
> - SectionLayout에 px-4 sm:px-6 md:px-8 lg:px-10 xl:px-12처럼 다양한 뷰포트 사이즈별로 좌우 여백을 설정
> 

<br/>

> ### 반응형 적용
>
> - 그리드 구조 재설정기본 1열에서 시작해 태블릿 환경에서는 2열, 데스크톱 환경에서는 5열을 사용

> ### 리스트와 지도 사이 여백 적용
>
> - gap-8 md:gap-12를 적용해 카드 목록과 지도 사이의 여백 적용

> ### 지도 크기 조정
>
> - 지도영역에 h-64와 md:h-full을 사용해 모바일~데스크톱에서 균형 잡힌 크기 유지

<br/>



<br/>

> ### 변경 후 기대 효과
>
> (변경 후 기대되는 결과를 작성하세요.)
![image](https://github.com/user-attachments/assets/5ded8350-5b0a-4b23-92ed-d450ce32bee4)
![image](https://github.com/user-attachments/assets/eec4b906-7627-40c2-93c8-7b969591c898)
https://github.com/orgs/TitovCompany/projects/2/views/1?pane=issue&itemId=98676408&issue=TitovCompany%7CVisionlife_FE%7C141
https://github.com/orgs/TitovCompany/projects/2/views/1?pane=issue&itemId=98679514&issue=TitovCompany%7CVisionlife_FE%7C144

> ### 테스트 디바이스

> (iPadmini),(iPadair),(iPadPro),(Z Fold 2,3,4,5),(Z Flip 3,4,5)(iPhone16,Plus,ProMax)
