### PR TITLE
♻️ refactor - Home & Footer 페이지 반응형 디자인 개선

### DIFF
--- a/src/features/home/components/HomeNews.tsx
+++ b/src/features/home/components/HomeNews.tsx
@@ -11,8 +11,8 @@ const HomeNews = () => {
   const sliderRef = useInfiniteCarousel();
 
   return (
-    <section className="h-auto overflow-hidden py-20">
-      <div className="mb-10 ml-12 text-2xl font-semibold">
+    <section className="h-auto overflow-hidden py-12 sx:py-16 sm:py-20">
+      <div className="mb-5 sm:mb-10 ml-3 xs:ml-5 sm:ml-12 text-xl sm:text-2xl font-semibold">
         <h3 className="flex items-center gap-3">
           <AiOutlineArrowDown className="text-primary font-extrabold" />
           비전라이프 최근 소식

--- a/src/features/home/components/MoreNewsSection.tsx
+++ b/src/features/home/components/MoreNewsSection.tsx
@@ -3,8 +3,8 @@ import {LuCircleArrowRight} from 'react-icons/lu';
 
 const MoreNewsSection = () => {
   return (
-    <div className="flex flex-col items-center justify-between gap-5 md:flex-row">
-      <div className="flex w-full flex-col items-center justify-center gap-5 md:w-1/2 md:items-start">
+    <div className="flex flex-col items-center justify-between gap-5 lg:flex-row">
+      <div className="flex w-full flex-col items-center justify-center gap-5 lg:w-1/2 lg:items-start">
         <h3 className="max-w-sm text-2xl leading-relaxed font-semibold sm:text-3xl">
           더 많은 소식 확인하기
         </h3>
@@ -16,7 +16,7 @@ const MoreNewsSection = () => {
           <span>모든 소식 보기</span>
         </TextLink>
       </div>
-      <div className="hidden w-full md:block md:w-1/2">
+      <div className="hidden w-full lg:block md:w-1/2">
         <div className="flex h-full w-full justify-center py-10">
           <img
             src="/img/logo.png"

--- a/src/features/home/index.tsx
+++ b/src/features/home/index.tsx
@@ -19,10 +19,10 @@ const Home = () => {
       isFullHeight={false}
       isMinHeight={false}>
       <HeroSection
-        sectionClass="h-[410px] md:h-[635px] grid grid-cols-1 grid-rows-1"
+        sectionClass="h-[310px] sm:h-[410px] md:h-[635px] grid grid-cols-1 grid-rows-1"
         src={imageSrc} />
-      <div className="mx-auto h-auto w-full max-w-2xl">
-        <h2 className="pt-10 pb-10 text-center text-lg leading-relaxed font-semibold md:pt-20 md:text-3xl">
+      <div className="mx-auto h-auto w-full max-w-md xs:max-w-2xl">
+        <h2 className="pt-10 pb-10 text-center text-base xs:text-lg leading-relaxed font-semibold md:pt-20 md:text-3xl">
           <span className="text-primary">비전라이프</span>는 지속 가능한 미래를
           그리며<br />세상을 연결하는 친환경 기술을 만들어 갑니다.
         </h2>

--- a/src/features/news/components/NewsCard.tsx
+++ b/src/features/news/components/NewsCard.tsx
@@ -15,7 +15,7 @@ const NewsCard: React.FC<NewsCardProps> = (props) => {
     <li className="h-full w-full rounded-xl">
       <Link
         to={`/company/news/${news.id}`}
-        className="flex w-[350px] flex-col overflow-hidden rounded-xl shadow-md transition duration-300 hover:opacity-80">
+        className="flex w-[250px] h-[300px] sm:w-[350px] flex-col overflow-hidden rounded-xl transition duration-300 hover:opacity-80">
         <img
           src={
             isDefaultImg
@@ -27,7 +27,7 @@ const NewsCard: React.FC<NewsCardProps> = (props) => {
           loading="lazy"
         />
         <div className="flex h-40 w-full flex-grow flex-col rounded-b-xl bg-[#f3f3f3] px-6 pt-6 pb-10">
-          <h3 className="mb-2 w-full text-lg font-semibold break-words whitespace-normal text-gray-800">
+          <h3 className="mb-2 w-full text-lg font-semibold break-words whitespace-normal text-gray-800 line-clamp-2">
             {news.title}
           </h3>
           {isDescription && (

--- a/src/features/profile/components/HeroSection.tsx
+++ b/src/features/profile/components/HeroSection.tsx
@@ -7,12 +7,8 @@ const HeroSection = ({src, sectionClass}: HeroSectionProps) => {
   return (
     <section className={sectionClass}>
       <figure className="relative h-full w-full">
-        <img
-          className="h-full w-full object-cover"
-          src={src}
-          alt="Vision Image"
-        />
-        <figcaption className="absolute inset-0 flex flex-col items-center justify-center bg-black/50 text-4xl font-bold text-white sm:text-5xl md:text-7xl">
+        <img className="h-full w-full object-cover" src={src} alt="Vision Image"/>
+        <figcaption className="absolute inset-0 flex flex-col items-center justify-center bg-black/50 font-bold text-white text-3xl xs:text-4xl sm:text-5xl md:text-7xl">
           Vision !! <br /> Dreams Come True !!
         </figcaption>
       </figure>

--- a/src/features/profile/components/HeroSection.tsx
+++ b/src/features/profile/components/HeroSection.tsx
@@ -8,7 +8,7 @@ const HeroSection = ({src, sectionClass}: HeroSectionProps) => {
     <section className={sectionClass}>
       <figure className="relative h-full w-full">
         <img className="h-full w-full object-cover" src={src} alt="Vision Image"/>
-        <figcaption className="absolute inset-0 flex flex-col items-center justify-center bg-black/50 font-bold text-white text-3xl xs:text-4xl sm:text-5xl md:text-7xl">
+        <figcaption className="absolute inset-0 flex flex-col items-center justify-center bg-black/50 font-bold text-white text-3xl xs:text-4xl sm:text-5xl md:text-6xl lg:text-7xl">
           Vision !! <br /> Dreams Come True !!
         </figcaption>
       </figure>

--- a/src/layout/BusinessSectionLayout.tsx
+++ b/src/layout/BusinessSectionLayout.tsx
@@ -14,22 +14,20 @@ const BusinessSectionLayout: React.FC<BusinessSectionLayoutProps> = (props) => {
   const {title, description, src, art, href} = props;
   return (
     <section className="home_item mx-auto w-full max-w-sm py-4 md:max-w-6xl md:py-10">
-      <article className="flex flex-col gap-2 md:flex-row md:gap-20">
+      <article className="flex flex-col gap-2 lg:flex-row lg:gap-20">
         <img
           src={src}
           alt={art}
-          className="mx-auto w-80 h-80 sm:w-[370px] sm:h-[400px] rounded-xl object-cover md:mx-0 md:h-[500px] md:w-[600px]"
+          className="mx-auto w-80 h-80 sm:w-[370px] sm:h-[400px] rounded-xl object-cover lg:mx-0 md:h-[500px] md:w-[600px]"
         />
-        <div className="flex flex-col gap-5 py-5 md:w-full md:gap-10 md:py-10">
-          <div className="mx-auto max-w-xs md:mx-0 md:w-full md:max-w-2xl">
-            <h3 className="text-2xl font-bold md:w-full md:text-4xl">
-              {title}
-            </h3>
-            <p className="w-full pt-3 sm:pt-5 text-base sm:text-lg leading-relaxed md:pt-10 md:text-xl">
-              {description}
-            </p>
-          </div>
-          <Link to={href} className="ml-5 flex items-center justify-start sm:justify-center gap-4 text-xl md:justify-start">
+        <div className="flex flex-col gap-5 py-5 md:w-full mx-auto max-w-xs md:max-w-xl lg:max-w-2xl md:gap-6 lg:gap-10 md:py-10">
+          <h3 className="text-2xl font-bold md:w-full md:text-4xl">
+            {title}
+          </h3>
+          <p className="w-full text-base sm:text-lg leading-relaxed md:text-xl">
+            {description}
+          </p>
+          <Link to={href} className="flex items-center justify-start gap-4 text-xl">
             <LuCircleArrowRight className="text-primary font-extrabold" />더
             알아보기
           </Link>

--- a/src/layout/BusinessSectionLayout.tsx
+++ b/src/layout/BusinessSectionLayout.tsx
@@ -18,20 +18,18 @@ const BusinessSectionLayout: React.FC<BusinessSectionLayoutProps> = (props) => {
         <img
           src={src}
           alt={art}
-          className="mx-auto h-[400px] w-[370px] rounded-xl object-cover md:mx-0 md:h-[500px] md:w-[600px]"
+          className="mx-auto w-80 h-80 sm:w-[370px] sm:h-[400px] rounded-xl object-cover md:mx-0 md:h-[500px] md:w-[600px]"
         />
         <div className="flex flex-col gap-5 py-5 md:w-full md:gap-10 md:py-10">
           <div className="mx-auto max-w-xs md:mx-0 md:w-full md:max-w-2xl">
-            <h3 className="text-2xl font-medium md:w-full md:text-4xl">
+            <h3 className="text-2xl font-bold md:w-full md:text-4xl">
               {title}
             </h3>
-            <p className="w-full pt-5 text-lg leading-relaxed md:pt-10 md:text-xl">
+            <p className="w-full pt-3 sm:pt-5 text-base sm:text-lg leading-relaxed md:pt-10 md:text-xl">
               {description}
             </p>
           </div>
-          <Link
-            to={href}
-            className="ml-5 flex items-center justify-center gap-4 text-xl md:justify-start">
+          <Link to={href} className="ml-5 flex items-center justify-start sm:justify-center gap-4 text-xl md:justify-start">
             <LuCircleArrowRight className="text-primary font-extrabold" />더
             알아보기
           </Link>

--- a/src/layout/Footer/FooterColumn.tsx
+++ b/src/layout/Footer/FooterColumn.tsx
@@ -33,7 +33,7 @@ const FooterColumn: React.FC<FooterColumnProps> = memo((props) => {
   ${isOpen ? 'pb-6 max-h-40 opacity-100' : 'pb-0 max-h-0 opacity-0'}`);
 
   return (
-    <div className="mx-auto flex w-full max-w-xl xs:max-w-xs flex-col border-b border-b-gray-300 lg:border-b-0 lg:items-center">
+    <div className="mx-auto flex w-full max-w-xl xs:max-w-xs sm:max-w-sm md:max-w-xl flex-col border-b border-b-gray-300 lg:border-b-0 lg:items-center">
       <strong className={titleClasses} onClick={handleClick}>
         {title}
         <span className="text-gray-400 lg:hidden">

--- a/src/layout/Footer/FooterColumn.tsx
+++ b/src/layout/Footer/FooterColumn.tsx
@@ -33,7 +33,7 @@ const FooterColumn: React.FC<FooterColumnProps> = memo((props) => {
   ${isOpen ? 'pb-6 max-h-40 opacity-100' : 'pb-0 max-h-0 opacity-0'}`);
 
   return (
-    <div className="mx-auto flex w-full max-w-xl lg:max-w-xs flex-col border-b border-b-gray-300 lg:border-b-0 lg:items-center">
+    <div className="mx-auto flex w-full max-w-xl xs:max-w-xs flex-col border-b border-b-gray-300 lg:border-b-0 lg:items-center">
       <strong className={titleClasses} onClick={handleClick}>
         {title}
         <span className="text-gray-400 lg:hidden">

--- a/src/layout/Footer/FooterColumn.tsx
+++ b/src/layout/Footer/FooterColumn.tsx
@@ -25,18 +25,18 @@ const FooterColumn: React.FC<FooterColumnProps> = memo((props) => {
 
   const titleClasses = clsx(`
   w-full py-5 flex justify-between  items-center gap-2 text-lg font-semibold cursor-pointer 
-  md:mb-4 md:py-0 md:cursor-default md:justify-around`);
+  lg:mb-4 lg:py-0 lg:cursor-default lg:justify-around`);
 
   const listClasses = clsx(`
-   md:max-h-full md:opacity-100 md:text-center
+   lg:max-h-full lg:opacity-100 lg:text-center
    text-left overflow-hidden transition-all duration-300 
   ${isOpen ? 'pb-6 max-h-40 opacity-100' : 'pb-0 max-h-0 opacity-0'}`);
 
   return (
-    <div className="mx-auto flex w-full max-w-xs flex-col border-b border-b-gray-300 sm:border-b-0 md:items-center">
+    <div className="mx-auto flex w-full max-w-xl lg:max-w-xs flex-col border-b border-b-gray-300 lg:border-b-0 lg:items-center">
       <strong className={titleClasses} onClick={handleClick}>
         {title}
-        <span className="text-gray-400 md:hidden">
+        <span className="text-gray-400 lg:hidden">
           {isOpen ? <FaChevronUp /> : <FaChevronDown />}
         </span>
       </strong>
@@ -45,7 +45,7 @@ const FooterColumn: React.FC<FooterColumnProps> = memo((props) => {
         {sortedLinks.map((item, index) => (
           <li
             key={index}
-            className="hover:text-primary pb-5 transition md:pb-0">
+            className="hover:text-primary pb-5 transition lg:pb-0">
             <Link to={item.path}>{item.name}</Link>
           </li>
         ))}

--- a/src/layout/Footer/index.tsx
+++ b/src/layout/Footer/index.tsx
@@ -43,7 +43,7 @@ const Footer = memo(() => {
   return (
     <footer className="border-t border-t-gray-200 bg-[#f3f3f3] py-10">
       <div className="mx-auto max-w-4xl">
-        <div className="mx-auto flex max-w-4xl flex-col justify-between gap-5 text-base md:flex-row md:gap-20">
+        <div className="mx-auto flex max-w-4xl flex-col justify-between gap-5 text-base lg:flex-row lg:gap-20">
           {footer.map((item, index) => (
             <FooterColumn
               key={index}
@@ -57,7 +57,7 @@ const Footer = memo(() => {
         <div className="my-8 border-t border-t-gray-200"></div>
 
         {/*저작권*/}
-        <div className="flex flex-col-reverse items-center justify-between gap-4 px-4 text-base sm:flex-row">
+        <div className="flex flex-col-reverse items-center justify-between gap-4 px-4 text-base lg:flex-row">
           <p className="text-center">
             © 2025 VisionLife. All Rights Reserved.
           </p>


### PR DESCRIPTION
> ## PR 타입

- [ ] 기능 추가
- [x] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
> ### Home 페이지 반응형 디자인 작업
- 기본 모바일 디자인 적용 (Galaxy Z Fold 5, 344x882) (CL: 455)
- 펼쳤을 때 상태 반응형 적용 (Galaxy Z Fold 5, 690x829) (CL: 456)

<br/>

> ### Footer 컴포넌트 반응형 디자인 작업
- 기본 모바일 디자인 적용 (Galaxy Z Fold 5, 690x829) (CL: 457)
- xs(365px) 해상도 대응 (Galaxy A51/71, 412x914) (CL: 458)
- sm(460px) / md(640px) 해상도 대응 (CL: 459)
  - iPad Air (829x1180) / iPad Mini (768x1024) 디바이스에서 테스트 및 적용
