### PR TITLE
♻️ refactor: 모바일 환경에서 TabNavbar 대신 드롭다운 메뉴 적용

### DIFF
--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import {NavLink} from 'react-router-dom';
+import {FaChevronDown, FaChevronUp} from 'react-icons/fa';
+import useToggle from '../hooks/useToggle.ts';
+
+interface Dropdown {
+  title: string;
+  href: string;
+}
+
+interface DropdownProps {
+  title: string;
+  items: Dropdown[];
+}
+
+const Dropdown: React.FC<DropdownProps> = ({
+  title,
+  items
+}) => {
+  const { isOpen, toggle, close } = useToggle();
+
+  return (
+    <div className="relative block md:hidden">
+      <button
+        onClick={toggle}
+        className="w-full px-4 py-4 bg-gray-200 rounded-md flex items-center justify-center gap-3">
+        <span className="text-base font-semibold">{title}</span>
+        <span className="text-base font-semibold text-gray-400">
+          {isOpen ? <FaChevronUp /> : <FaChevronDown />}
+        </span>
+      </button>
+      {isOpen && (
+        <ul className="absolute left-0 w-full bg-white shadow-md rounded-md mt-2">
+          {items.map((item, idx) => (
+            <li key={idx}>
+              <NavLink
+                to={item.href}
+                className="block px-4 py-3 text-center hover:bg-gray-100"
+                onClick={close}>
+                {item.title}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default Dropdown;

--- a/src/features/profile/index.tsx
+++ b/src/features/profile/index.tsx
@@ -4,6 +4,7 @@ import TabList from '../../components/Tab/TabList.tsx';
 import TabNavLinkItem from '../../components/Tab/TabNavLinkItem.tsx';
 import PageLayout from '../../layout/PageLayout.tsx';
 import {NavLink, Outlet} from 'react-router-dom';
+import Dropdown from '../../components/Dropdown.tsx';
 
 const TAB_LIST = [
   {title: '회사 소개', href: '/company/profile'},
@@ -24,7 +25,7 @@ const ProfileLayout = () => {
 
       {/* TabList: 모바일에서는 세로 full-width, sm 이상에서는 인라인 배치 */}
       <div className="bg-[#f3f3f3]">
-        <TabList className="mx-auto flex max-w-5xl flex-wrap justify-center gap-8">
+        <TabList className="hidden max-w-5xl mx-auto md:flex md:flex-wrap md:justify-center md:gap-8">
           {TAB_LIST.map((item, idx) => (
             <TabNavLinkItem
               key={idx}
@@ -36,6 +37,7 @@ const ProfileLayout = () => {
             />
           ))}
         </TabList>
+        <Dropdown title="메뉴 보기" items={TAB_LIST} />
       </div>
       <Outlet />
     </PageLayout>

--- a/src/features/profile/pages/ContactUs.tsx
+++ b/src/features/profile/pages/ContactUs.tsx
@@ -41,8 +41,8 @@
     return (
       <SectionLayout
         title="CONTACT US"
-        className="mx-auto px-4 sm:px-6 md:px-8 lg:px-5 flex max-w-6xl xl:max-w-7xl flex-col items-center justify-center py-12 sm:py-16 lg:py-20"
-        titleClassName="py-6 text-3xl lg:text-4xl font-semibold text-center"
+        className="mx-auto px-4 sm:px-6 md:px-8 lg:px-5 flex max-w-6xl xl:max-w-7xl flex-col items-center justify-center py-6 md:py-12 sm:py-16 lg:py-20"
+        titleClassName="py-6 text-2xl sm:text-3xl lg:text-4xl font-semibold text-center"
         fullHeight={false}
       >
         {/* 연락처 정보 */}

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -1,0 +1,17 @@
+import { useState, useCallback } from "react";
+
+const useToggle = (initialState = false) => {
+  const [isOpen, setIsOpen] = useState(initialState);
+
+  const toggle = useCallback(() => {
+    setIsOpen((prev) => !prev);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return { isOpen, toggle, close };
+};
+
+export default useToggle;

--- a/src/layout/Footer/FooterColumn.tsx
+++ b/src/layout/Footer/FooterColumn.tsx
@@ -1,7 +1,8 @@
-import React, {memo, useMemo, useState} from 'react';
+import React, {memo, useMemo} from 'react';
 import {Link} from 'react-router-dom';
 import {FaChevronDown, FaChevronUp} from 'react-icons/fa';
 import clsx from 'clsx';
+import useToggle from '../../hooks/useToggle.ts';
 
 interface FooterColumnProps {
   title: string;
@@ -13,11 +14,11 @@ interface SubLinks {
   path: string;
 }
 
-const FooterColumn: React.FC<FooterColumnProps> = memo((props) => {
-  const {title, subLinks} = props;
-  const [isOpen, setIsOpen] = useState(false);
-
-  const handleClick = () => setIsOpen(!isOpen);
+const FooterColumn: React.FC<FooterColumnProps> = memo(({
+  title,
+  subLinks
+}) => {
+  const { isOpen, toggle } = useToggle();
 
   const sortedLinks = useMemo(() => {
     return [...subLinks].sort((a, b) => a.name.localeCompare(b.name));
@@ -34,7 +35,7 @@ const FooterColumn: React.FC<FooterColumnProps> = memo((props) => {
 
   return (
     <div className="mx-auto flex w-full max-w-xs sm:max-w-sm md:max-w-xl flex-col border-b border-b-gray-300 lg:border-b-0 lg:items-center">
-      <strong className={titleClasses} onClick={handleClick}>
+      <strong className={titleClasses} onClick={toggle}>
         {title}
         <span className="text-gray-400 lg:hidden">
           {isOpen ? <FaChevronUp /> : <FaChevronDown />}


### PR DESCRIPTION
> ## PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
> ### 드롭다운 메뉴 컴포넌트 생성
- 작은 화면에서는 가독성을 높이기 위해 TabNavbar 대신 드롭다운 메뉴를 사용
- 반응형 디자인을 고려하여 md 이상에서는 기존 TabNavbar 유지 (CL: 472)

> ### useToggle 커스텀 훅 생성
- isOpen 상태를 공통으로 관리하기 위해 useToggle 훅을 생성
- isOpen, toggle(), close() 등의 메서드를 제공하여 재사용성을 높임
- Dropdown에서 메뉴 클릭 시 자동으로 닫히도록 적용하여 UX 개선