### PR TITLE
refactor: 모바일 화면에서 히어로 섹션과 메뉴의 세로 간격이 없게 수정,타임라인 반응형 레이아웃 조정 

### DIFF
--- a/src/features/history/Card.tsx
+++ b/src/features/history/Card.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface CardProps {
+  title: string;
+  event: string[] | string;
+  description?: string;
+}
+
+const Card: React.FC<CardProps> = ({ title, event, description }) => (
+  <div className="max-w-md p-6 mt-5 text-left">
+    <h3 className="mb-3 text-lg md:text-2xl font-bold">{title}</h3>
+    {Array.isArray(event) ? (
+      <ul className="text-base text-gray-700">
+        {event.map((e, i) => (
+          <li key={i}>{e}</li>
+        ))}
+      </ul>
+    ) : (
+      <p className="text-base text-gray-700">{event}</p>
+    )}
+    {description && <p className="mt-2 text-sm text-gray-500">{description}</p>}
+  </div>
+);
+
+export default Card; 

--- a/src/features/history/Dot.tsx
+++ b/src/features/history/Dot.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Dot: React.FC = () => (
+  <div className="absolute left-1/2 lg:left-1/2 top-[30px] lg:top-[48px] z-10 w-6 h-6 -translate-x-1/2 rounded-full border-4 border-primary bg-white hidden lg:block"></div>
+);
+
+export default Dot; 

--- a/src/features/history/HistoryTimeline.tsx
+++ b/src/features/history/HistoryTimeline.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Year from './Year';
+import Dot from './Dot';
+import Card from './Card';
+
+interface HistoryTimelineItemProps {
+  id: string;
+  year: string;
+  title: string;
+  event: string[] | string;
+  description?: string;
+}
+
+const HistoryTimelineItem: React.FC<HistoryTimelineItemProps> = ({ id, year, title, event, description }) => (
+  <li
+    key={id}
+    className="history-timeline-item relative mb-20 flex flex-col md:flex-row w-full justify-between items-start text-left"
+  >
+    <Dot />
+    <div className="max-w-md  p-6 mt-1 text-left">
+      <Year year={year} />
+    </div>
+    <Card title={title} event={event} description={description} />
+  </li>
+);
+
+export default HistoryTimelineItem; 

--- a/src/features/history/Year.tsx
+++ b/src/features/history/Year.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface YearProps {
+  year: string;
+}
+
+const Year: React.FC<YearProps> = ({ year }) => {
+  const isRange = year.includes('~');
+  const [startYear, endYear] = isRange ? year.split('~') : [year, null];
+
+  return (
+    <h2 className="inline-block py-1 text-3xl md:text-5xl font-semibold text-primary">
+      <span className="flex md:hidden">
+        {isRange ? `${startYear}년 ~ ${endYear}년` : `${year}년`}
+      </span>
+      <span className="hidden md:flex flex-col items-center">
+        {isRange ? (
+          <>
+            <span>{startYear}년</span>
+            <span className="text-xl md:text-3xl">~</span>
+            <span>{endYear}년</span>
+          </>
+        ) : (
+          <span>{year}년</span>
+        )}
+      </span>
+    </h2>
+  );
+};
+
+export default Year; 

--- a/src/features/history/index.tsx
+++ b/src/features/history/index.tsx
@@ -1,6 +1,7 @@
 import GridLayout from '../../layout/Grid/GridLayout.tsx';
 import GridArticle from '../../layout/Grid/GridArticle.tsx';
 import history from '../../data/profile/history.json';
+import HistoryTimeline from './HistoryTimeline.tsx';
 //import clsx from 'clsx';
 
 const History = () => {
@@ -33,55 +34,16 @@ const History = () => {
       <GridArticle colStart={1} colEnd={13}>
      <div className="relative mx-auto w-full max-w-full py-10 before:absolute before:inset-y-0 before:left-1/2 before:w-1 before:bg-primary before:-translate-x-1/2 before:hidden lg:before:block">
       <ul className='relative'>
-            {history.map((item) => {
-              const isRange = item.year.includes('~');
-              const [startYear, endYear] = isRange ? item.year.split('~') : [item.year, null];
-
-              return (
-                <li
-                  key={item.id}
-                  className="history-timeline-item relative mb-20 flex flex-col md:flex-row w-full justify-between items-start text-left"
-                >
-                  {/* dot */}
-                  <div className="absolute left-1/2 lg:left-1/2 top-[30px] lg:top-[48px] z-10 w-6 h-6 -translate-x-1/2 rounded-full border-4 border-primary bg-white hidden lg:block"></div>
-
-                  {/* 연도 */}
-                  <div className="max-w-md  p-6 mt-1 text-left">
-                    <h2 className="inline-block py-1 text-3xl md:text-5xl font-semibold text-primary">
-                      <span className="flex md:hidden">
-                        {isRange ? `${startYear}년 ~ ${endYear}년` : `${item.year}년`}
-                      </span>
-                      <span className="hidden md:flex flex-col items-center">
-                        {isRange ? (
-                          <>
-                            <span>{startYear}년</span>
-                            <span className="text-xl md:text-3xl">~</span>
-                            <span>{endYear}년</span>
-                          </>
-                        ) : (
-                          <span>{item.year}년</span>
-                        )}
-                      </span>
-                    </h2>
-                  </div>
-
-                  {/* 카드 */}
-                  <div className="max-w-md p-6 mt-5 text-left">
-                    <h3 className="mb-3 text-lg md:text-2xl font-bold">{item.title}</h3>
-                    {Array.isArray(item.event) ? (
-                      <ul className="text-base text-gray-700">
-                        {item.event.map((e, i) => (
-                          <li key={i}>{e}</li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <p className="text-base text-gray-700">{item.event}</p>
-                    )}
-                    <p className="mt-2 text-sm text-gray-500">{item.description}</p>
-                  </div>
-                </li>
-              );
-            })}
+            {history.map((item) => (
+              <HistoryTimeline
+                key={String(item.id)}
+                id={String(item.id)}
+                year={item.year}
+                title={item.title}
+                event={item.event}
+                description={item.description}
+              />
+            ))}
           </ul>
         </div>
       </GridArticle>

--- a/src/features/history/index.tsx
+++ b/src/features/history/index.tsx
@@ -4,84 +4,91 @@ import history from '../../data/profile/history.json';
 //import clsx from 'clsx';
 
 const History = () => {
- return (
+  return (
    <GridLayout className='gap-y-0'>
-    {/* Hero */}
-    <GridArticle>
-     <video
-       width='100%'
-       height='100%'
-       src='/video/history.mp4'
-       controls={false}
-       autoPlay
-       loop
-       muted
-       playsInline
-     />
-     {/* Header */}
-     <div className='absolute top-1/2 left-1/2 mb-10 -translate-x-1/2 -translate-y-1/2 text-center font-bold text-white md:mb-20'>
-      <h2 className='mb-4 text-2xl md:mb-10 md:text-6xl'>비젼라이프의 여정</h2>
-      <h3 className='text-lg leading-10 md:text-3xl'>
-       더 나은 미래를 위한 혁신과 도전,
-       <br />
-       비전라이프가 걸어온 길을 함께합니다.
-      </h3>
-     </div>
-    </GridArticle>
+      {/* Hero */}
+      <GridArticle className="relative aspect-video w-full min-h-[220px] md:min-h-[400px] overflow-hidden">
+        <video
+          className="w-full h-full object-cover"
+          src="/video/history.mp4"
+          controls={false}
+          autoPlay
+          loop
+          muted
+          playsInline
+        />
+        {/* Header */}
+        <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/40 pt-20 md:pt-0">
+          <h2 className="mb-2 text-lg font-bold text-white drop-shadow md:mb-6 md:text-5xl">
+            비젼라이프의 여정
+          </h2>
+          <h3 className="text-xs leading-6 text-white drop-shadow md:text-2xl md:leading-10 text-center">
+            더 나은 미래를 위한 혁신과 도전,<br />
+            비전라이프가 걸어온 길을 함께합니다.
+          </h3>
+        </div>
+      </GridArticle>
 
-    {/* 타임라인 History */}
-    <GridArticle colStart={1} colEnd={13}>
-     <div className="relative mx-auto w-full max-w-full py-10 before:absolute before:inset-y-0 before:left-1/2 before:w-1 before:bg-primary before:-translate-x-1/2">
+      {/* 타임라인 History */}
+      <GridArticle colStart={1} colEnd={13}>
+     <div className="relative mx-auto w-full max-w-full py-10 before:absolute before:inset-y-0 before:left-1/2 before:w-1 before:bg-primary before:-translate-x-1/2 before:hidden lg:before:block">
       <ul className='relative'>
-       {history.map((item) => {
-        return (
-          <li
-            key={item.id}
-            className="relative mb-20 flex w-full justify-between pl-10"
-          >
-           {/* dot */}
-           <div className="absolute left-1/2 top-[30px] z-10 w-6 h-6 -translate-x-1/2 rounded-full border-4 border-primary bg-white"></div>
+            {history.map((item) => {
+              const isRange = item.year.includes('~');
+              const [startYear, endYear] = isRange ? item.year.split('~') : [item.year, null];
 
-           {/* 연도 */}
-           <div className="max-w-md rounded-xl p-6 text-left mt-1">
-            <h2 className="inline-block py-1 text-5xl font-semibold text-primary">
-      <span className="flex flex-col items-center">
-        {item.year.includes('~') ? (
-          <>
-           <span>{item.year.split('~')[0]}년</span>
-           <span className="text-3xl">~</span>
-           <span>{item.year.split('~')[1]}년</span>
-          </>
-        ) : (
-          `${item.year}년`
-        )}
-      </span>
-            </h2>
-           </div>
+              return (
+                <li
+                  key={item.id}
+                  className="history-timeline-item relative mb-20 flex flex-col md:flex-row w-full justify-between items-start text-left"
+                >
+                  {/* dot */}
+                  <div className="absolute left-1/2 lg:left-1/2 top-[30px] lg:top-[48px] z-10 w-6 h-6 -translate-x-1/2 rounded-full border-4 border-primary bg-white hidden lg:block"></div>
 
-           {/* card */}
-           <div className="max-w-md rounded-xl p-6 text-left mt-1">
-            <h3 className="mb-3 text-2xl font-bold">{item.title}</h3>
-            {Array.isArray(item.event) ? (
-              <ul className="text-base text-gray-700">
-               {item.event.map((e, i) => (
-                 <li key={i}>{e}</li>
-               ))}
-              </ul>
-            ) : (
-              <p className="text-base text-gray-700">{item.event}</p>
-            )}
-            <p className="mt-2 text-sm text-gray-500">{item.description}</p>
-           </div>
-          </li>
+                  {/* 연도 */}
+                  <div className="max-w-md  p-6 mt-1 text-left">
+                    <h2 className="inline-block py-1 text-3xl md:text-5xl font-semibold text-primary">
+                      <span className="flex md:hidden">
+                        {isRange ? `${startYear}년 ~ ${endYear}년` : `${item.year}년`}
+                      </span>
+                      <span className="hidden md:flex flex-col items-center">
+                        {isRange ? (
+                          <>
+                            <span>{startYear}년</span>
+                            <span className="text-xl md:text-3xl">~</span>
+                            <span>{endYear}년</span>
+                          </>
+                        ) : (
+                          <span>{item.year}년</span>
+                        )}
+                      </span>
+                    </h2>
+                  </div>
 
-        );
-       })}
-      </ul>
-     </div>
-    </GridArticle>
-   </GridLayout>
- );
+                  {/* 카드 */}
+                  <div className="max-w-md p-6 mt-5 text-left">
+                    <h3 className="mb-3 text-lg md:text-2xl font-bold">{item.title}</h3>
+                    {Array.isArray(item.event) ? (
+                      <ul className="text-base text-gray-700">
+                        {item.event.map((e, i) => (
+                          <li key={i}>{e}</li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="text-base text-gray-700">{item.event}</p>
+                    )}
+                    <p className="mt-2 text-sm text-gray-500">{item.description}</p>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </GridArticle>
+    </GridLayout>
+  );
 };
 
 export default History;
+
+	

--- a/src/layout/PageLayout.tsx
+++ b/src/layout/PageLayout.tsx
@@ -16,8 +16,11 @@ const PageLayout: React.FC<PageLayoutProps> = ({
 }) => {
  return (
   <main ref={ref} className={clsx(
-    'w-full pt-[calc(102px)] min-h-screen',
-    'bg-white', className)}>
+    'w-full min-h-screen',
+    'bg-white',           
+    'lg:pt-[calc(102px)]', // lg 이상에서만 패딩
+    className
+  )}>
    {/* SEO 최적화용 */}
    <h1 className='hidden'>{title}</h1>
    {children}


### PR DESCRIPTION
> ## PR 타입

- [ ] 기능 추가
- [X] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항

> ### 모바일 환경 메뉴와 히어로 섹션의 간격 제거
>
> 'lg:pt-[calc(102px)]', 
lg 이상에서만 패딩으로 변경하여 모바일에서의 간격이 제거되었습니다.
<img width="292" alt="스크린샷 2025-07-02 오후 3 06 52" src="https://github.com/user-attachments/assets/f7710608-9594-4173-864b-bebb44efbdbb" />

<br/>

> ### 타임라인 페이지 반응형 레이아웃 조정

데스크탑 연도 선 카드 구조 
테스트 기기 UDEA Monitor 
<img width="1440" alt="스크린샷 2025-07-02 오후 3 08 31" src="https://github.com/user-attachments/assets/654299ea-ba6f-402f-9a9d-b2dd85e3a743" />
테블릿  연도 카드 구조
테스트 기기 iPad Pro,iPad mini,iPad Air
<img width="386" alt="스크린샷 2025-07-02 오후 3 09 30" src="https://github.com/user-attachments/assets/a406b665-f2b3-4f26-97a6-779d4ca7409e" />

모바일 년도 카드 세로 구조  모바일에서는 년도를 가로로 한 줄로 표시하도록 변경
테스트 기기 iPhone 12Pro,iPhone 14Pro Max,iPhone SE
<img width="280" alt="스크린샷 2025-07-02 오후 3 10 07" src="https://github.com/user-attachments/assets/1779592a-a7d0-415e-92f9-9ecf1f4e1875" />

> ###  연도,점,카드 부분 별도 컴포넌트로 분리

기존의 index.tsx에 있던 연도,점,카드 컴포넌트를 따로 분리하였습니다. [b7d5f58]
