### PR TITLE
refactor:  메인페이지 반응형 레이아웃 조정

### DIFF
--- a/src/features/home/index.tsx
+++ b/src/features/home/index.tsx
@@ -66,10 +66,10 @@ const Home = () => {
   <>
    <Header />
    <main className='min-h-screen w-full bg-white text-center'>
-    <GridLayout  className='scrollbar-hide mb-52' >
+    <GridLayout className='scrollbar-hide mb-20 md:mb-52'>
      {/* Hero */}
      <GridArticle
-      className='bg-primary relative flex h-screen min-w-screen flex-col text-white'>
+      className='bg-primary relative flex min-h-[60vh] md:h-screen min-w-screen flex-col text-white'>
       <HeroSlider data={carouselItems} currentIndex={currentIndex} setCurrentIndex={setCurrentIndex}/>
      </GridArticle>
 
@@ -77,13 +77,13 @@ const Home = () => {
      <GridArticle
       colStart={2}
       colEnd={12}
-      className='flex h-screen w-full flex-col justify-center'>
+      className='flex min-h-[60vh] md:h-screen w-full flex-col justify-center'>
       <SectionHeader
        id='company'
        title='Company'
-       subTitle='비전라이프홀딩스는 ‘사람과 환경이 공존하는 섬유산업’을 꿈꿉니다.'
+       subTitle="비전라이프홀딩스는 '사람과 환경이 공존하는 섬유산업'을 꿈꿉니다."
       />
-      <ul className='mt-32 flex items-center justify-between gap-10'>
+      <ul className='mt-10 md:mt-32 flex flex-col md:flex-row items-center md:items-center justify-between gap-4 md:gap-10'>
        <LinkList href='/' imgSrc='/img/home/Cp1.webp' text='About Company' />
        <LinkList href='/' imgSrc='/img/home/Cp1.webp' text='History' />
        <LinkList href='/' imgSrc='/img/home/Cp2.webp' text='Business' />
@@ -96,24 +96,24 @@ const Home = () => {
       colStart={2}
       colEnd={12}
       labelledById="why-choose-us"
-      className='flex h-screen flex-col justify-center text-center'>
+      className='flex min-h-[60vh] md:h-screen flex-col justify-center text-center'>
       <SectionHeader
        id="why-choose-us"
        title='Why Choose Us?'
        subTitle='지속 가능성과 품질을 동시에 제공합니다.'
       />
       {/* Contents */}
-      <ul className='mt-32 grid grid-cols-1 gap-8 md:grid-cols-3'>
+      <ul className='mt-10 md:mt-32 grid grid-cols-1 gap-8 md:grid-cols-3'>
        {features.map((feature, index) => (
         <li
          key={index}
-         /*ref={(el) => {
+        /*ref={(el) => {
           if (el) contentRef.current[index] = el;
          }}*/
          className='flex flex-col items-center text-center'>
-         <img src={feature.image} alt='' width={300} height={300}/>
-         <h3 className='mt-4 text-2xl font-semibold'>{feature.title}</h3>
-         <p className='mt-2 text-gray-600'>{feature.description}</p>
+         <img src={feature.image} alt='' className="w-32 h-32 md:w-[180px] md:h-[180px] lg:w-[300px] lg:h-[300px] object-contain"/>
+         <h3 className='mt-4 text-lg md:text-2xl font-semibold'>{feature.title}</h3>
+         <p className='mt-2 text-gray-600 text-sm md:text-base'>{feature.description}</p>
         </li>
        ))}
       </ul>
@@ -123,17 +123,17 @@ const Home = () => {
      <GridArticle
       colStart={2}
       colEnd={12}
-      className='flex h-screen snap-start flex-col justify-center'>
+      className='flex min-h-[60vh] md:h-screen snap-start flex-col justify-center'>
       <SectionHeader
        title='Global Business'
        subTitle={[
         '비전라이프는 글로벌 시장에서 지속 가능한 기술을 바탕으로',
         '새로운 가치를 창출하고 있습니다.',
        ]}/>
-      <div className='h-[800px] min-w-[600px]'>
+      <div className='w-full h-[300px] md:h-[800px] min-w-0 md:min-w-[600px] flex justify-center items-center'>
        <ThreeDScene />
       </div>
-      <div className='text-lg'>
+      <div className='text-base md:text-lg mt-4 md:mt-0 px-2 md:px-0 text-left md:text-center'>
        {[
         '비전라이프는 중국 DTP 기계 제조업체와 협력하여 전시장을 운영 중이며,',
         '다양한 원단에 대한 샘플링을 통해 글로벌 시장 진입을 준비하고 있습니다.',
@@ -151,26 +151,26 @@ const Home = () => {
      <GridArticle
       colStart={2}
       colEnd={12}
-      className='flex h-screen flex-col items-start justify-center gap-20'>
+      className='flex min-h-[60vh] md:h-screen flex-col items-start justify-center gap-10 md:gap-20'>
       <SectionHeader
        title='NEWS'
        subTitle={[
         '친환경 기술과 지속 가능한 변화를 만드는',
         'PROUTEX의 최신 소식을 만나보세요.',
        ]}/>
-      <div className='flex gap-5 overflow-x-visible'>
+      <div className='flex flex-col md:flex-row gap-4 md:gap-5 w-full overflow-x-visible'>
        {/* Media Carousel */}
        {news.items.slice(0, 3).map((item, index) => (
-        <Card key={index} className='border-color relative flex flex-1 flex-col items-start justify-around border-2 p-8'>
-         <img src='/logo.webp' alt='test' className='object-contain' width={300} height={300}/>
-         <div className='border-color mt-10 mr-10 w-full text-left'>
-          <h3 className='mb-5 text-xl'>{item.title}</h3>
+        <Card key={index} className='border-color relative flex flex-row items-center md:flex-col flex-1 border-2 p-4 md:p-8'>
+         <img src='/logo.webp' alt='test' className='object-contain w-24 h-24 md:w-[180px] md:h-[180px] lg:w-[300px] lg:h-[300px]'/>
+         <div className='border-color ml-4 md:ml-0 mt-0 md:mt-10 mr-0 md:mr-10 w-full text-left'>
+          <h3 className='mb-2 md:mb-5 text-base md:text-xl'>{item.title}</h3>
          </div>
         </Card>
        ))}
       </div>
-      <div className='mx-auto w-full flex justify-center items-center text-xl'>
-       <Link to='/' className='border-2 px-10 py-4 font-bold'>
+      <div className='mx-auto w-full flex justify-center items-center text-base md:text-xl'>
+       <Link to='/' className='border-2 px-6 py-2 md:px-10 md:py-4 font-bold'>
         VIEW ALL
        </Link>
       </div>

--- a/src/features/home/index.tsx
+++ b/src/features/home/index.tsx
@@ -75,21 +75,23 @@ const Home = () => {
 
      {/* Company */}
      <GridArticle
-      colStart={2}
-      colEnd={12}
-      className='flex min-h-[60vh] md:h-screen w-full flex-col justify-center'>
-      <SectionHeader
-       id='company'
-       title='Company'
-       subTitle="비전라이프홀딩스는 '사람과 환경이 공존하는 섬유산업'을 꿈꿉니다."
-      />
-      <ul className='mt-10 md:mt-32 flex flex-col md:flex-row items-center md:items-center justify-between gap-4 md:gap-10'>
-       <LinkList href='/' imgSrc='/img/home/Cp1.webp' text='About Company' />
-       <LinkList href='/' imgSrc='/img/home/Cp1.webp' text='History' />
-       <LinkList href='/' imgSrc='/img/home/Cp2.webp' text='Business' />
-       <LinkList href='/' imgSrc='/img/home/Cp3.webp' text='Location' />
+      className='md:col-start-2 md:col-end-12 flex min-h-[60vh] md:h-screen w-full flex-col justify-center'
+     >
+      <div className='px-4 md:px-0'>
+        <SectionHeader
+          id='company'
+          title='Company'
+          subTitle="비전라이프홀딩스는 '사람과 환경이 공존하는 섬유산업'을 꿈꿉니다."
+        />
+      </div>
+      <ul className='mt-10 md:mt-32 flex flex-col md:flex-row items-center justify-between gap-4 md:gap-10 w-full'>
+        <LinkList href='/' imgSrc='/img/home/Cp1.webp' text='About Company' />
+        <LinkList href='/' imgSrc='/img/home/Cp1.webp' text='History' />
+        <LinkList href='/' imgSrc='/img/home/Cp2.webp' text='Business' />
+        <LinkList href='/' imgSrc='/img/home/Cp3.webp' text='Location' />
       </ul>
      </GridArticle>
+
 
      {/* WhyUsSection */}
      <GridArticle


### PR DESCRIPTION
> ## PR 타입

- [ ] 기능 추가
- [X] 리팩토링
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항

> ### 메인페이지의 반응형 레이아웃 조정
>테스트 기기 IPhone se,IPhone 14 Pro Max


Company 세로로 정렬(수정전)
![image](https://github.com/user-attachments/assets/1bed84af-5bcb-47f3-8abd-730a7d92aca7)
</br>
Company 세로로 정렬(수정후)
![image](https://github.com/user-attachments/assets/4821b92c-844c-4661-b81e-c6e0e3257432)
</br>
</br>
WhyUsSection 세로로 정렬
![image](https://github.com/user-attachments/assets/ccd298f1-3875-4e00-8c53-df55c5220f99)
</br>
Global Business 모바일에서는 텍스트 중앙정렬 대신 왼쪽정렬하게 변경 하였습니다
![image](https://github.com/user-attachments/assets/8d56cf77-2ac4-4f91-9896-d901e1cb4795)
</br>

News 뉴스는 세로로 쌓이는 구조로 변경하고 이미지 타이틀을 flex row 정렬로 변경하였습니다
![image](https://github.com/user-attachments/assets/f470cd9f-3ca1-40d1-bd08-7d18c3550050)


